### PR TITLE
Ch5. 웹 어댑터 구현하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+	implementation ('org.springframework.boot:spring-boot-starter-web')
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/io/reflectoring/buckpal/account/adapter/in/web/SendMoneyController.java
+++ b/src/main/java/io/reflectoring/buckpal/account/adapter/in/web/SendMoneyController.java
@@ -1,0 +1,30 @@
+package io.reflectoring.buckpal.account.adapter.in.web;
+import io.reflectoring.buckpal.account.application.port.in.SendMoneyCommand;
+import io.reflectoring.buckpal.account.application.port.in.SendMoneyUseCase;
+import io.reflectoring.buckpal.account.domain.Account.AccountId;
+import io.reflectoring.buckpal.account.domain.Money;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SendMoneyController {
+
+    private final SendMoneyUseCase sendMoneyUseCase;
+
+    @PostMapping(path = "/accounts/send/{sourceAccountId}/{targetAccountId}/{amount}")
+    void sendMoney(
+            @PathVariable("sourceAccountId") Long sourceAccountId,
+            @PathVariable("targetAccountId") Long targetAccountId,
+            @PathVariable("amount") Long amount) {
+
+        SendMoneyCommand command = new SendMoneyCommand(
+                new AccountId(sourceAccountId),
+                new AccountId(targetAccountId),
+                Money.of(amount));
+
+        sendMoneyUseCase.sendMoney(command);
+    }
+}


### PR DESCRIPTION
웹 인터페이스를 제공하는 어댑터의 구현 방법을 살펴보자.

## 웹 어댑터의 책임

- HTTP 요청을 자바 객체로 매핑
- 권한 검사
- 입력 유효성 검증
- 입력을 유스케이스의 입력 모델로 매핑
- 유스케이스 호출
- 유스케이스 출력을 HTTP로 매핑
- HTTP 응답을 반환

웹 어댑터의 입력 모델을 유스케이스의 입력 모델로 변환할 수 있다는 것을 검증해야 한다.

HTTP와 관련된 것은 애플리케이션 계층으로 침투해서는 안된다.

## 컨트롤러 나누기

- 모든 연산을 단일 컨트롤러에 넣는 것이 데이터 구조의 재활용을 촉진한다.

## 유지보수 가능한 소프트웨어 만들기

- 웹 어댑터 구현 시에는 HTTP 요청을 애플리케이션의 유스케이스에 대한 메서드 호출로 변환하고 결과를 다시 HTTP로 변환하고 어떤 도메인 로직도 수행하지 않는 어댑터를 만들고 있다는 점을 염두에 둬야한다.
- 애플리케이션 계층은 HTTP에 대한 상세 정보를 노출시키지 않도록 HTTP와 관련된 작업을 해서는 안된다.