### PR TITLE
Ch6. 영속성 어댑터 구현하기

### DIFF
--- a/src/main/java/io/reflectoring/buckpal/account/adapter/out/persistence/AccountJpaEntity.java
+++ b/src/main/java/io/reflectoring/buckpal/account/adapter/out/persistence/AccountJpaEntity.java
@@ -1,0 +1,22 @@
+package io.reflectoring.buckpal.account.adapter.out.persistence;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "account")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccountJpaEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+}

--- a/src/main/java/io/reflectoring/buckpal/account/adapter/out/persistence/AccountMapper.java
+++ b/src/main/java/io/reflectoring/buckpal/account/adapter/out/persistence/AccountMapper.java
@@ -1,0 +1,60 @@
+package io.reflectoring.buckpal.account.adapter.out.persistence;
+
+import io.reflectoring.buckpal.account.domain.Account;
+import io.reflectoring.buckpal.account.domain.Account.AccountId;
+
+import io.reflectoring.buckpal.account.domain.Activity;
+import io.reflectoring.buckpal.account.domain.Activity.ActivityId;
+import io.reflectoring.buckpal.account.domain.ActivityWindow;
+import io.reflectoring.buckpal.account.domain.Money;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class AccountMapper {
+    Account mapToDomainEntity(
+            AccountJpaEntity account,
+            List<ActivityJpaEntity> activities,
+            Long withdrawalBalance,
+            Long depositBalance) {
+
+        Money baselineBalance = Money.subtract(
+                Money.of(depositBalance),
+                Money.of(withdrawalBalance));
+
+        return Account.withId(
+                new AccountId(account.getId()),
+                baselineBalance,
+                mapToActivityWindow(activities));
+
+    }
+
+    ActivityWindow mapToActivityWindow(List<ActivityJpaEntity> activities) {
+        List<Activity> mappedActivities = new ArrayList<>();
+
+        for (ActivityJpaEntity activity : activities) {
+            mappedActivities.add(new Activity(
+                    new ActivityId(activity.getId()),
+                    new AccountId(activity.getOwnerAccountId()),
+                    new AccountId(activity.getSourceAccountId()),
+                    new AccountId(activity.getTargetAccountId()),
+                    activity.getTimestamp(),
+                    Money.of(activity.getAmount())));
+        }
+
+        return new ActivityWindow(mappedActivities);
+    }
+
+    ActivityJpaEntity mapToJpaEntity(Activity activity) {
+        return new ActivityJpaEntity(
+                activity.getId() == null ? null : activity.getId().getValue(),
+                activity.getTimestamp(),
+                activity.getOwnerAccountId().getValue(),
+                activity.getSourceAccountId().getValue(),
+                activity.getTargetAccountId().getValue(),
+                activity.getMoney().getAmount().longValue());
+    }
+
+}

--- a/src/main/java/io/reflectoring/buckpal/account/adapter/out/persistence/AccountPersistenceAdapter.java
+++ b/src/main/java/io/reflectoring/buckpal/account/adapter/out/persistence/AccountPersistenceAdapter.java
@@ -1,0 +1,66 @@
+package io.reflectoring.buckpal.account.adapter.out.persistence;
+
+import io.reflectoring.buckpal.account.application.port.out.LoadAccountPort;
+import io.reflectoring.buckpal.account.application.port.out.UpdateAccountStatePort;
+import io.reflectoring.buckpal.account.domain.Account;
+import io.reflectoring.buckpal.account.domain.Account.AccountId;
+import io.reflectoring.buckpal.account.domain.Activity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class AccountPersistenceAdapter implements LoadAccountPort, UpdateAccountStatePort {
+    private final SpringDataAccountRepository accountRepository;
+    private final ActivityRepository activityRepository;
+    private final AccountMapper accountMapper;
+
+    @Override
+    public Account loadAccount(
+            AccountId accountId,
+            LocalDateTime baselineDate) {
+
+        AccountJpaEntity account =
+                accountRepository.findById(accountId.getValue())
+                        .orElseThrow(EntityNotFoundException::new);
+
+        List<ActivityJpaEntity> activities =
+                activityRepository.findByOwnerSince(
+                        accountId.getValue(),
+                        baselineDate);
+
+        Long withdrawalBalance = orZero(activityRepository
+                                                .getWithdrawalBalanceUntil(
+                                                        accountId.getValue(),
+                                                        baselineDate));
+
+        Long depositBalance = orZero(activityRepository
+                                             .getDepositBalanceUntil(
+                                                     accountId.getValue(),
+                                                     baselineDate));
+
+        return accountMapper.mapToDomainEntity(
+                account,
+                activities,
+                withdrawalBalance,
+                depositBalance);
+
+    }
+
+    private Long orZero(Long value){
+        return value == null ? 0L : value;
+    }
+
+    @Override
+    public void updateActivities(Account account) {
+        for (Activity activity : account.getActivityWindow().getActivities()) {
+            if (activity.getId() == null) {
+                activityRepository.save(accountMapper.mapToJpaEntity(activity));
+            }
+        }
+    }
+}

--- a/src/main/java/io/reflectoring/buckpal/account/adapter/out/persistence/ActivityJpaEntity.java
+++ b/src/main/java/io/reflectoring/buckpal/account/adapter/out/persistence/ActivityJpaEntity.java
@@ -1,0 +1,39 @@
+package io.reflectoring.buckpal.account.adapter.out.persistence;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "activity")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ActivityJpaEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column
+    private LocalDateTime timestamp;
+
+    @Column
+    private Long ownerAccountId;
+
+    @Column
+    private Long sourceAccountId;
+
+    @Column
+    private Long targetAccountId;
+
+    @Column
+    private Long amount;
+}

--- a/src/main/java/io/reflectoring/buckpal/account/adapter/out/persistence/ActivityRepository.java
+++ b/src/main/java/io/reflectoring/buckpal/account/adapter/out/persistence/ActivityRepository.java
@@ -1,0 +1,34 @@
+package io.reflectoring.buckpal.account.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ActivityRepository extends JpaRepository<ActivityJpaEntity, Long> {
+    @Query("select a from ActivityJpaEntity a " +
+            "where a.ownerAccountId = :ownerAccountId " +
+            "and a.timestamp >= :since")
+    List<ActivityJpaEntity> findByOwnerSince(
+            @Param("ownerAccountId") Long ownerAccountId,
+            @Param("since") LocalDateTime since);
+
+    @Query("select sum(a.amount) from ActivityJpaEntity a " +
+            "where a.targetAccountId = :accountId " +
+            "and a.ownerAccountId = :accountId " +
+            "and a.timestamp < :until")
+    Long getDepositBalanceUntil(
+            @Param("accountId") Long accountId,
+            @Param("until") LocalDateTime until);
+
+    @Query("select sum(a.amount) from ActivityJpaEntity a " +
+            "where a.sourceAccountId = :accountId " +
+            "and a.ownerAccountId = :accountId " +
+            "and a.timestamp < :until")
+    Long getWithdrawalBalanceUntil(
+            @Param("accountId") Long accountId,
+            @Param("until") LocalDateTime until);
+
+}

--- a/src/main/java/io/reflectoring/buckpal/account/adapter/out/persistence/SpringDataAccountRepository.java
+++ b/src/main/java/io/reflectoring/buckpal/account/adapter/out/persistence/SpringDataAccountRepository.java
@@ -1,0 +1,6 @@
+package io.reflectoring.buckpal.account.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataAccountRepository extends JpaRepository<AccountJpaEntity, Long> {
+}


### PR DESCRIPTION
영속성 계층을 애플리케이션 계층의 플러그인으로 만들어보자.

## 의존성 역전

- 애플리케이션 서비스에서는 영속성 기능을 사용하기 위해 포트 인터페이스를 호출한다.
- 이 포트는 실제로 영속성 작업을 수행하고 데이터베이스와 통신할 책임을 가진 영속성 어댑터 클래스에 의해 구현된다.
- 영속성 문제에 신경 쓰지 않고 도메인 코드를 개발하기 위해, 즉 영속성 계층에 대한 코드 의존성을 없애기 위해 간접 계층을 추가한다.

## 영속성 어댑터의 책임

1. 입력을 받는다
2. 입력을 데이터베이스 포맷으로 매핑한다
3. 입력을 데이터베이스로 보낸다
4. 데이터베이스 출력을 애플리케이션 포맷으로 매핑한다
5. 출력을 반환한다

- 영속성 어댑터는 포트를 통해 입력을 받는다.
- 그 후 데이터베이스를 쿼리하거나 변경하는 데 사용할 수 있는 포맷으로 입력모델을 매핑한다.
    - 자바에서는 JPA 엔티티 객체로 매핑
    - 영속성 어댑터의 입력 모델이 영속성 어댑터 내부에 있는 것이 아니라 애플리케이션 코어에 있기 때문에 영속성 어댑터 내부를 변경하는 것이 코어에 영향을 미치지 않는다.
- 데이터베이스에 쿼리를 날리고 쿼리 결과를 받아온다.
- 데이터베이스 응답을 포트에 정의된 출력 모델로 매핑해서 반환한다.
    - 출력 모델이 영속성 어댑터가 아니라 애플리케이션 코어에 위치하는 것이 중요하다.
    

## 트랜잭션

트랜잭션은 하나의 특정한 유스케이스에 대해서 일어나는 모든 쓰기 작업에 걸쳐 있어야 한다.

그래야 그 중 하나라도 실패할 경우 다 같이 롤백 될 수 있기 때문이다.

@Transactional 어노테이션 활용

좁은 포트 인터페이스를 사용하면 포트마다 다른 방식으로 구현할 수 있는 유연함이 생긴다.